### PR TITLE
Python3

### DIFF
--- a/volt/plugin/builtins/atomic/__init__.py
+++ b/volt/plugin/builtins/atomic/__init__.py
@@ -13,6 +13,7 @@ Atom feed generator plugin.
 
 from __future__ import with_statement
 import os
+import sys
 from datetime import datetime
 
 from jinja2 import Environment, FileSystemLoader
@@ -74,5 +75,8 @@ class AtomicPlugin(Plugin):
 
         # render and write to output file
         rendered = template.render(units=engine.units[:10], CONFIG=CONFIG, time=time)
+        
         with open(self.config.OUTPUT_FILE, 'w') as target:
-            target.write(rendered.encode('utf-8'))
+            if sys.version_info[0] < 3:
+                rendered = rendered.encode('utf-8')
+            target.write(rendered)


### PR DESCRIPTION
Hi there,

volt refused to run on python3, so I took the liberty to apply 3 patches that make it run with both python3 and python2. At least the tests still seem to run for both python2 and 3 and I can "volt serve" with both python2 and python3.

Would be nice if you had a look at them.
