### PR TITLE
gitignore *.pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # general / os-specific
+*.pyc
 *.swp
 *.gz
 .DS_STORE


### PR DESCRIPTION
As you said, the *.pyc .gitignore patch is good to go, but it conflicts with current master. So here is the merge request for just this patch, updated to current master.
