### PR TITLE
More verbose error on duplicate post title

### DIFF
--- a/volt/engine/core.py
+++ b/volt/engine/core.py
@@ -386,7 +386,8 @@ class Engine(LoggableMixin):
             # this indicates a duplicate post, which could result in
             # unexpected results
             if os.path.exists(item.path):
-                message = "File %s already exists." % item.path
+                message = "File %s already exists. Make sure there are no "\
+                          "other entries leading to this file path." % item.path
                 self.logger.error(message)
                 raise IOError(message)
             else:

--- a/volt/generator.py
+++ b/volt/generator.py
@@ -227,7 +227,8 @@ class Generator(LoggableMixin):
             template = CONFIG.SITE.TEMPLATE_ENV.get_template(filename)
             path = os.path.join(CONFIG.VOLT.SITE_DIR, filename)
             if os.path.exists(path):
-                message = "'%s' already exists." % path
+                message = "File %s already exists. Make sure there are no "\
+                          "other entries leading to this file path." % path
                 console("Error: %s" % message, is_bright=True, color='red')
                 self.logger.error(message)
                 sys.exit(1)


### PR DESCRIPTION
I was stumped by the "file already exists" error message until I
realized it was a backup copy of my file leading to duplicate post
entries. This is a more verbose error message hinting towards that
as a potential error.

This merge request is the updated version with the wording you have proposed.
