### PR TITLE
python3: Make urllib play nice with python3 and python2

### DIFF
--- a/volt/templates/demo/widgets.py
+++ b/volt/templates/demo/widgets.py
@@ -66,7 +66,11 @@ def github_search():
         {% endfor %}
     """
     import json
-    import urllib
+    try: #try python3 first
+        from urllib.request import urlopen
+        from urllib.parse import urlencode
+    except ImportError: # fallback to python2
+        from urllib import urlencode, urlopen
     from datetime import datetime
     from volt.utils import console
 
@@ -76,9 +80,9 @@ def github_search():
     base_url = 'http://github.com/api/v2/json/repos/search/'
 
     # retrieve search results using urllib and json
-    query = '%s%s' % (query_string.replace(' ', '+'), '?' + urllib.urlencode(args))
+    query = '%s%s' % (query_string.replace(' ', '+'), '?' + urlencode(args))
     try:
-        response = urllib.urlopen(base_url + query).read()
+        response = urlopen(base_url + query).read().decode('utf-8')
     except IOError:
         console("WARNING: github_search can not connect to the internet.\n", \
                 color='red', is_bright=True)


### PR DESCRIPTION
This is split out from https://github.com/bow/volt/pull/3

and contains only the urllib-related fix that you said are good to go. This works both on python3 and python2.

urllib has reorganized stuff with python3. Fortunately we can easily make both
play nicely together.
