### PR TITLE
use python-dateutil to parse the dates

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ docutils
 textile
 markdown
 pygments
-
+python-dateutil
 #setup.py develop
 -e .
 

--- a/volt/engine/core.py
+++ b/volt/engine/core.py
@@ -21,6 +21,7 @@ import re
 import sys
 import warnings
 from datetime import datetime
+import dateutil.parser as dateutil_parser
 from functools import partial, reduce
 from traceback import format_exc
 
@@ -596,7 +597,7 @@ class Unit(Page):
 
     # convenience methods
     open_text = partial(codecs.open, encoding='utf-8')
-    as_datetime = datetime.strptime
+    as_datetime = dateutil_parser
 
     def parse_header(self, header_string):
         """Returns a dictionary of header field values.
@@ -620,14 +621,14 @@ class Unit(Page):
                 value = self.as_list(value, self.config.LIST_SEP)
 
             elif field in self.config.FIELDS_AS_DATETIME:
-                value = self.as_datetime(value, \
-                        self.config.DATETIME_FORMAT)
+                value = self.as_datetime.parse(value)
+
 
             setattr(self, field.lower(), value)
 
     def check_protected(self, field, prot):
         """Checks if the given field can be set by the user or not.
-        
+
         field -- String to check against the list containing protected fields.
         prot -- Iterable returning string of protected fields.
 


### PR DESCRIPTION
I'm pretty bad at remembering of what the datetime format is.  This pull request adds in using the most excellent python-dateutil, which parses anything that my resembling a date and parsing it to a datetime object. Of course, if you don't put in a year, it will make it the current year.

This also much destroys putting in  any date formats. This pull request still has them in the configuration but, if you decided to accept it, I would make the changes in removing them. 

Let me know what you think.
